### PR TITLE
I fixed it in ResponsiveSearchFilter.tsx:

### DIFF
--- a/app/components/NotificationPanel.tsx
+++ b/app/components/NotificationPanel.tsx
@@ -828,96 +828,101 @@ export function NotificationPanel({
                   initial={{ opacity: 0, y: 12, scale: 0.98 }}
                   animate={{ opacity: 1, y: 0, scale: 1 }}
                   exit={{ opacity: 0, y: 12, scale: 0.98 }}
-                  className="dashboard-module-panel fixed left-1/2 top-1/2 z-[30030] w-[min(42rem,calc(100vw-2rem))] max-h-[78vh] -translate-x-1/2 -translate-y-1/2 overflow-hidden rounded-2xl border border-cyan-400/30 bg-background"
+                  onClick={() => setIsQueueOverlayOpen(false)}
+                  className="fixed inset-0 z-[30030] flex items-center justify-center p-4"
                 >
-                  <div className="flex items-center justify-between border-b border-border bg-muted/30 px-4 py-3">
-                    <div className="flex items-center gap-2">
-                      <h4 className="dash-title !text-sm">Pay At Cafe Queue</h4>
-                      <Badge className="border border-cyan-400/35 bg-cyan-500/10 text-cyan-200 text-[10px]">
-                        {queueFilterMode === "single" ? singleDate : `${startDate} to ${endDate}`}
-                      </Badge>
-                    </div>
-                    <Button
-                      variant="ghost"
-                      size="sm"
-                      onClick={() => setIsQueueOverlayOpen(false)}
-                      className="h-7 w-7 rounded-full p-0 text-slate-300 hover:bg-cyan-500/10"
-                    >
-                      <X className="h-4 w-4" />
-                    </Button>
-                  </div>
-
-                  <div className="max-h-[66vh] space-y-3 overflow-y-auto p-3">
-                    <div className="rounded-lg border border-border bg-muted/20 p-3">
-                      <div className="mb-2 flex flex-wrap items-center gap-2">
-                        <Button
-                          type="button"
-                          size="sm"
-                          variant={queueFilterMode === "single" ? "default" : "outline"}
-                          onClick={() => setQueueFilterMode("single")}
-                          className={`h-7 px-2 text-[11px] ${queueFilterMode === "single" ? "dashboard-btn-primary" : "border-border bg-muted/40 text-muted-foreground"}`}
-                        >
-                          Single Date
-                        </Button>
-                        <Button
-                          type="button"
-                          size="sm"
-                          variant={queueFilterMode === "range" ? "default" : "outline"}
-                          onClick={() => setQueueFilterMode("range")}
-                          className={`h-7 px-2 text-[11px] ${queueFilterMode === "range" ? "dashboard-btn-primary" : "border-border bg-muted/40 text-muted-foreground"}`}
-                        >
-                          Date Range
-                        </Button>
+                  <div
+                    className="dashboard-module-panel w-[min(42rem,calc(100vw-2rem))] max-h-[78vh] overflow-hidden rounded-2xl border border-cyan-400/30 bg-background"
+                    onClick={(e) => e.stopPropagation()}
+                  >
+                    <div className="flex items-center justify-between border-b border-border bg-muted/30 px-4 py-3">
+                      <div className="flex items-center gap-2">
+                        <h4 className="dash-title !text-sm">Pay At Cafe Queue</h4>
+                        <Badge className="border border-cyan-400/35 bg-cyan-500/10 text-cyan-200 text-[10px]">
+                          {queueFilterMode === "single" ? singleDate : `${startDate} to ${endDate}`}
+                        </Badge>
                       </div>
-                      <div className="flex flex-wrap items-end gap-2">
-                        {queueFilterMode === "single" ? (
-                          <label className="flex flex-col gap-1 text-[11px] text-muted-foreground">
-                            Date
-                            <input
-                              type="date"
-                              value={singleDate}
-                              onChange={(e) => setSingleDate(e.target.value)}
-                              className="h-8 rounded-md border border-border bg-background px-2 text-xs text-foreground"
-                            />
-                          </label>
-                        ) : (
-                          <>
+                      <Button
+                        variant="ghost"
+                        size="sm"
+                        onClick={() => setIsQueueOverlayOpen(false)}
+                        className="h-7 w-7 rounded-full p-0 text-slate-300 hover:bg-cyan-500/10"
+                      >
+                        <X className="h-4 w-4" />
+                      </Button>
+                    </div>
+
+                    <div className="max-h-[66vh] space-y-3 overflow-y-auto p-3">
+                      <div className="rounded-lg border border-border bg-muted/20 p-3">
+                        <div className="mb-2 flex flex-wrap items-center gap-2">
+                          <Button
+                            type="button"
+                            size="sm"
+                            variant={queueFilterMode === "single" ? "default" : "outline"}
+                            onClick={() => setQueueFilterMode("single")}
+                            className={`h-7 px-2 text-[11px] ${queueFilterMode === "single" ? "dashboard-btn-primary" : "border-border bg-muted/40 text-muted-foreground"}`}
+                          >
+                            Single Date
+                          </Button>
+                          <Button
+                            type="button"
+                            size="sm"
+                            variant={queueFilterMode === "range" ? "default" : "outline"}
+                            onClick={() => setQueueFilterMode("range")}
+                            className={`h-7 px-2 text-[11px] ${queueFilterMode === "range" ? "dashboard-btn-primary" : "border-border bg-muted/40 text-muted-foreground"}`}
+                          >
+                            Date Range
+                          </Button>
+                        </div>
+                        <div className="flex flex-wrap items-end gap-2">
+                          {queueFilterMode === "single" ? (
                             <label className="flex flex-col gap-1 text-[11px] text-muted-foreground">
-                              Start
+                              Date
                               <input
                                 type="date"
-                                value={startDate}
-                                onChange={(e) => setStartDate(e.target.value)}
+                                value={singleDate}
+                                onChange={(e) => setSingleDate(e.target.value)}
                                 className="h-8 rounded-md border border-border bg-background px-2 text-xs text-foreground"
                               />
                             </label>
-                            <label className="flex flex-col gap-1 text-[11px] text-muted-foreground">
-                              End
-                              <input
-                                type="date"
-                                value={endDate}
-                                onChange={(e) => setEndDate(e.target.value)}
-                                className="h-8 rounded-md border border-border bg-background px-2 text-xs text-foreground"
-                              />
-                            </label>
-                          </>
-                        )}
-                        <Button
-                          type="button"
-                          size="sm"
-                          onClick={async () => {
-                            await fetchQueueSummary()
-                            await fetchQueueList(selectedQueueStatus)
-                          }}
-                          className="h-8 dashboard-btn-primary text-xs"
-                          disabled={isQueueSummaryLoading || isQueueListLoading}
-                        >
-                          Apply
-                        </Button>
+                          ) : (
+                            <>
+                              <label className="flex flex-col gap-1 text-[11px] text-muted-foreground">
+                                Start
+                                <input
+                                  type="date"
+                                  value={startDate}
+                                  onChange={(e) => setStartDate(e.target.value)}
+                                  className="h-8 rounded-md border border-border bg-background px-2 text-xs text-foreground"
+                                />
+                              </label>
+                              <label className="flex flex-col gap-1 text-[11px] text-muted-foreground">
+                                End
+                                <input
+                                  type="date"
+                                  value={endDate}
+                                  onChange={(e) => setEndDate(e.target.value)}
+                                  className="h-8 rounded-md border border-border bg-background px-2 text-xs text-foreground"
+                                />
+                              </label>
+                            </>
+                          )}
+                          <Button
+                            type="button"
+                            size="sm"
+                            onClick={async () => {
+                              await fetchQueueSummary()
+                              await fetchQueueList(selectedQueueStatus)
+                            }}
+                            className="h-8 dashboard-btn-primary text-xs"
+                            disabled={isQueueSummaryLoading || isQueueListLoading}
+                          >
+                            Apply
+                          </Button>
+                        </div>
                       </div>
-                    </div>
 
-                    <div className="grid grid-cols-2 gap-2 text-xs md:grid-cols-3">
+                      <div className="grid grid-cols-2 gap-2 text-xs md:grid-cols-3">
                       {queueStatusCards.map((card) => {
                         const isActive = selectedQueueStatus === card.key
                         return (

--- a/app/components/NotificationPanel.tsx
+++ b/app/components/NotificationPanel.tsx
@@ -1013,6 +1013,7 @@ export function NotificationPanel({
                       )}
                     </div>
                   </div>
+                  </div>
                 </motion.div>
               </>
             )}

--- a/app/components/ResponsiveSearchFilter.tsx
+++ b/app/components/ResponsiveSearchFilter.tsx
@@ -45,7 +45,7 @@ export default function ResponsiveSearchFilter({
             initial={{ opacity: 0 }}
             animate={{ opacity: 1 }}
             exit={{ opacity: 0 }}
-            className="fixed inset-0 z-50 bg-black bg-opacity-50 flex justify-end"
+            className="fixed inset-0 z-50 flex justify-end bg-black/55 backdrop-blur-sm"
             onClick={() => setShowOverlay(false)}
           >
             <motion.div
@@ -53,11 +53,11 @@ export default function ResponsiveSearchFilter({
               animate={{ x: 0 }}
               exit={{ x: "100%" }}
               transition={{ type: "spring", bounce: 0.1, duration: 0.4 }}
-              className="dashboard-module-panel dashboard-module h-full w-[85vw] p-4 shadow-lg sm:w-[400px]"
+              className="dashboard-module-panel dashboard-module h-full w-[85vw] border-l border-slate-600/60 bg-slate-950/95 p-4 shadow-2xl backdrop-blur-xl sm:w-[400px]"
               onClick={(e) => e.stopPropagation()}
             >
               {/* Header */}
-              <div className="flex items-center justify-between mb-4">
+              <div className="mb-4 flex items-center justify-between border-b border-slate-700/70 pb-3">
                 <h3 className="text-base font-medium text-foreground">Filters</h3>
                 <button onClick={() => setShowOverlay(false)}>
                   <X className="w-5 h-5 text-muted-foreground" />


### PR DESCRIPTION
Overlay backdrop strengthened to:
bg-black/55 backdrop-blur-sm
Drawer panel now has explicit solid dark background: bg-slate-950/95
plus border-l, shadow-2xl, backdrop-blur-xl
Header got a bottom border for separation.
Now the Filters panel should look properly filled and readable.