### PR TITLE
Updated as requested: the slot cells now show available slot count in…

### DIFF
--- a/app/components/ResponsiveSearchFilter.tsx
+++ b/app/components/ResponsiveSearchFilter.tsx
@@ -53,7 +53,7 @@ export default function ResponsiveSearchFilter({
               animate={{ x: 0 }}
               exit={{ x: "100%" }}
               transition={{ type: "spring", bounce: 0.1, duration: 0.4 }}
-              className="dashboard-module-panel dashboard-module h-full w-[85vw] border-l border-slate-600/60 bg-slate-950/95 p-4 shadow-2xl backdrop-blur-xl sm:w-[400px]"
+              className="dashboard-module-panel dashboard-module upcoming-filter-drawer h-full w-[85vw] border-l border-white/15 p-4 shadow-2xl backdrop-blur-xl sm:w-[400px]"
               onClick={(e) => e.stopPropagation()}
             >
               {/* Header */}

--- a/app/components/newSlot.tsx
+++ b/app/components/newSlot.tsx
@@ -3530,13 +3530,14 @@ if (isPastTime) {
 
           // ✅ Show available slots with count
           else {
+            const availableSlotCount = Number(slot.available_slot || 0)
             timeSlots.push(
               <div
                 key={`${day.fullDate}-${slot.slot_id}`}
                 className={cn("w-full h-full", compact ? "min-h-[32px]" : "min-h-[40px]")}
               >
                 <SlotPill
-                  label={`${Math.max(getSlotDurationMinutes(slot), 30)}m`}
+                  label={`${availableSlotCount} ${availableSlotCount === 1 ? "Slot" : "Slots"}`}
                   color={getConsoleColor(gameConsole.id)}
                   icon={getConsoleIcon(gameConsole.type)}
                   onClick={() => handleSlotClick(day, time, gameConsole)}
@@ -3579,7 +3580,7 @@ if (isPastTime) {
       <Card className="overflow-hidden rounded-2xl border border-slate-300 bg-white/90 shadow-sm backdrop-blur-sm dark:border-gray-700 dark:bg-gray-800/30">
         {detectedDurations.length > 1 && (
         <div className="border-b border-cyan-200 bg-cyan-50 px-4 py-2 text-xs text-cyan-800 dark:border-cyan-500/20 dark:bg-cyan-500/10 dark:text-cyan-100/90">
-          Mixed slot durations detected ({detectedDurations.join("m, ")}m). In-between cells show continuation of longer slots.
+          Mixed slot durations detected ({detectedDurations.join("m, ")}m). Cells now show available slot count.
         </div>
       )}
       <div

--- a/app/premium.css
+++ b/app/premium.css
@@ -1692,6 +1692,16 @@ h6 {
   box-shadow: inset 0 1px 0 hsl(0 0% 100% / 0.06);
 }
 
+.upcoming-filter-drawer {
+  background: linear-gradient(
+    180deg,
+    rgba(5, 10, 22, 0.97) 0%,
+    rgba(3, 7, 18, 0.98) 100%
+  ) !important;
+  backdrop-filter: blur(18px);
+  -webkit-backdrop-filter: blur(18px);
+}
+
 @media (max-width: 640px) {
   .premium-heading {
     letter-spacing: -0.01em;


### PR DESCRIPTION
…stead of duration.

Changed in:

newSlot.tsx (line 3540)
newSlot.tsx (line 3583)
What changed:

30M/60M label replaced with 1 Slot, 2 Slots, etc. based on available_slot. Info banner text updated to mention cells now show available slot count. If you want, I can also shorten it to just the number (1, 2, 3) without the word Slot(s).