### PR TITLE
The settle overlay was being mounted inside the live-session panel tr…

### DIFF
--- a/app/components/current-slot.tsx
+++ b/app/components/current-slot.tsx
@@ -1900,7 +1900,7 @@ export function CurrentSlots({ currentSlots: initialSlots, historyBookings: init
             </div>
           )}
           
-          {activeTab === 'live' && (
+          {activeTab === 'live' && isMounted && createPortal(
             <ExtraBookingOverlay
               showOverlay={showOverlay}
               setShowOverlay={setShowOverlay}
@@ -1912,7 +1912,8 @@ export function CurrentSlots({ currentSlots: initialSlots, historyBookings: init
               calculateExtraAmount={calculateExtraAmount}
               formatTime={formatTime}
               releaseSlot={releaseSlot}
-            />
+            />,
+            document.body
           )}
 
           {contactOverlay.open && (


### PR DESCRIPTION
…ee, so mobile clipping could happen.

I changed only the mount point:

ExtraBookingOverlay is now rendered via createPortal(..., document.body) from current-slot, so it escapes panel bounds and won’t get cut on mobile.

current-slot
TSX
No logic change to settle flow and no desktop design rewrite. Please test:

Live Session → Settle
Confirm overlay now covers viewport on mobile and is not clipped.