### PR TITLE
I’ve patched this so Start is no longer a silent no-op.

### DIFF
--- a/app/components/upcoming-booking.tsx
+++ b/app/components/upcoming-booking.tsx
@@ -638,23 +638,20 @@ export function UpcomingBookings({
   }, [mergedBookings]);
 
   // Enhanced start session handler with debugging
-  const start = (system: string, gameId: string, bookingId: string, booking: any) => {
+  const start = (booking: any) => {
     const resolvedSystem = String(
-      system ||
       booking?.consoleType ||
       booking?.system ||
       booking?.game ||
       ""
     ).trim();
     const resolvedGameId = String(
-      gameId ??
       booking?.game_id ??
       booking?.gameId ??
       booking?.consoleTypeId ??
       ""
     ).trim();
     const resolvedBookingId = String(
-      bookingId ??
       booking?.bookingId ??
       booking?.booking_id ??
       booking?.bookId ??
@@ -664,9 +661,7 @@ export function UpcomingBookings({
     const resolvedVendorId = String(vendorId || "").trim();
 
     console.log('🚀 Start clicked with params:', {
-      system,
-      gameId,
-      bookingId,
+      booking,
       resolvedSystem,
       resolvedGameId,
       resolvedBookingId,
@@ -1376,10 +1371,13 @@ export function UpcomingBookings({
                           <motion.button
                             whileHover={{ scale: 1.02 }}
                             whileTap={{ scale: 0.98 }}
-                            onClick={() =>
-                              start(booking.consoleType || "", booking.game_id, booking.bookingId, booking)
-                            }
-                            disabled={!canStartNow}
+                            onClick={() => {
+                              if (!canStartNow) {
+                                showToast("Session can be started only during its scheduled time.", "error");
+                                return;
+                              }
+                              start(booking);
+                            }}
                             className={`inline-flex h-8 min-w-[96px] items-center justify-center gap-1 rounded-md !px-2.5 !py-0 text-[11px] font-semibold transition-all sm:min-w-[104px] sm:text-xs ${
                               canStartNow
                                 ? "dashboard-btn-primary"


### PR DESCRIPTION
What I changed:

Start now resolves IDs directly from the booking object (game_id/gameId, bookingId/booking_id, etc.) instead of depending on brittle argument ordering from the button call. upcoming-booking
TSX
The Start button now always gives feedback:
If booking is outside allowed time, it shows a toast instead of feeling broken. If required booking fields are missing, it shows a clear error toast. upcoming-booking
TSX

upcoming-booking
TSX
The click handler now calls start(booking) directly, so merged-row shape differences won’t break opening the console selector modal. upcoming-booking
TSX
Please refresh and test one booking in Upcoming:

If it’s within scheduled time, Select Console should open. If not, you should now see the exact reason via toast instead of nothing happening. If it still doesn’t open for a booking that should be startable, send one console log line from the new 🚀 Start clicked with params: output and I’ll finish the last edge immediately.