### PR TITLE
Implemented both pieces in hash-dashboard:

### DIFF
--- a/app/(features)/tournaments/[id]/page.tsx
+++ b/app/(features)/tournaments/[id]/page.tsx
@@ -15,6 +15,7 @@ import {
   getTeams, TeamItem, publishResults, WinnerInput,
   getEvent, getMatches, openCheckIn, closeCheckIn, generateBracket,
   startMatch, submitAdminMatchResult, resolveMatchDispute, TournamentMatch,
+  updateEvent,
 } from '@/lib/event-api';
 import { jwtDecode } from 'jwt-decode';
 import { DashboardLayout } from '@/app/(layout)/dashboard-layout';
@@ -31,6 +32,24 @@ const EVENT_STATUS_BADGE: Record<EventStatus, string> = {
   completed: 'bg-purple-500/20 text-purple-300 border border-purple-500/30',
   canceled:  'bg-red-500/20 text-red-300 border border-red-500/30',
 };
+
+const EVENT_STATUS_LABEL: Record<EventStatus, string> = {
+  draft: 'Draft',
+  published: 'Published',
+  ongoing: 'Live',
+  completed: 'Completed',
+  canceled: 'Canceled',
+};
+
+const EVENT_STATUS_HELP: Record<EventStatus, string> = {
+  draft: 'Hidden from public registration until you publish.',
+  published: 'Visible to players and open for registration.',
+  ongoing: 'Tournament is live and ready for match operations.',
+  completed: 'Tournament is finished and results are final.',
+  canceled: 'Tournament is stopped and should not accept operations.',
+};
+
+const EVENT_STATUS_FLOW: EventStatus[] = ['draft', 'published', 'ongoing', 'completed', 'canceled'];
 
 const REG_BADGE: Record<RegistrationStatus, string> = {
   confirmed: 'bg-green-500/20 text-green-400',
@@ -75,6 +94,8 @@ export default function TournamentDetailPage() {
   const [publishError,  setPublishError]  = useState<string | null>(null);
   const [engineError,   setEngineError]   = useState<string | null>(null);
   const [engineBusy,    setEngineBusy]    = useState<string | null>(null);
+  const [statusBusy,    setStatusBusy]    = useState<EventStatus | null>(null);
+  const [statusError,   setStatusError]   = useState<string | null>(null);
   const [selectedWinners, setSelectedWinners] = useState<Record<string, string>>({});
   const [publishing,    setPublishing]    = useState(false);
   const [winners,       setWinners]       = useState<WinnerInput[]>([
@@ -236,6 +257,23 @@ export default function TournamentDetailPage() {
       setEngineError(error?.message || 'Tournament engine action failed.');
     } finally {
       setEngineBusy(null);
+    }
+  };
+
+  const handleStatusChange = async (nextStatus: EventStatus) => {
+    if (!token || !event || nextStatus === event.status) return;
+    setStatusError(null);
+    setStatusBusy(nextStatus);
+    try {
+      await updateEvent(token, eventId, { status: nextStatus });
+      setEvent((prev) => prev ? { ...prev, status: nextStatus } : prev);
+      await refreshEventCache(true).then((ev) => {
+        if (ev) setEvent(ev);
+      }).catch(() => null);
+    } catch (error: any) {
+      setStatusError(error?.message || 'Failed to update tournament status.');
+    } finally {
+      setStatusBusy(null);
     }
   };
 
@@ -431,6 +469,54 @@ export default function TournamentDetailPage() {
             </div>
           </div>
         </div>
+      </div>
+
+      {/* ── Status Control ───────────────────────────── */}
+      <div className="gaming-panel rounded-xl border border-cyan-400/20 bg-slate-950/45 p-4 sm:p-5">
+        <div className="flex flex-wrap items-start justify-between gap-3">
+          <div>
+            <h3 className="section-title">Tournament Status</h3>
+            <p className="premium-subtle mt-1 text-sm">
+              Current state: {EVENT_STATUS_LABEL[event.status]}. {EVENT_STATUS_HELP[event.status]}
+            </p>
+          </div>
+          <span className={`rounded-full px-3 py-1 text-xs font-semibold ${EVENT_STATUS_BADGE[event.status]}`}>
+            {EVENT_STATUS_LABEL[event.status]}
+          </span>
+        </div>
+
+        <div className="mt-4 grid grid-cols-2 gap-2 md:grid-cols-5">
+          {EVENT_STATUS_FLOW.map((status) => {
+            const active = status === event.status;
+            const busy = statusBusy === status;
+            return (
+              <button
+                key={status}
+                type="button"
+                disabled={active || !!statusBusy}
+                onClick={() => handleStatusChange(status)}
+                className={`rounded-lg border px-3 py-2 text-left transition-all disabled:cursor-not-allowed ${
+                  active
+                    ? 'border-emerald-400/35 bg-emerald-500/10 text-emerald-100'
+                    : 'border-cyan-400/15 bg-slate-900/60 text-slate-300 hover:border-cyan-300/45 hover:bg-slate-800/80 hover:text-cyan-100 disabled:opacity-55'
+                }`}
+              >
+                <span className="block text-xs font-bold uppercase tracking-wider">
+                  {busy ? 'Updating...' : EVENT_STATUS_LABEL[status]}
+                </span>
+                <span className="mt-1 block text-[11px] leading-4 text-slate-400">
+                  {EVENT_STATUS_HELP[status]}
+                </span>
+              </button>
+            );
+          })}
+        </div>
+
+        {statusError && (
+          <div className="mt-3 rounded-lg border border-rose-400/30 bg-rose-500/10 px-3 py-2 text-sm text-rose-200">
+            {statusError}
+          </div>
+        )}
       </div>
 
       {/* ── Stat Pills ────────────────────────────────── */}

--- a/app/(features)/tournaments/create/page.tsx
+++ b/app/(features)/tournaments/create/page.tsx
@@ -4,7 +4,10 @@ import { useState, useRef, useEffect } from 'react';
 import { useRouter } from 'next/navigation';
 import {
   ChevronLeft, ChevronRight, CalendarDays,
-  Upload, X, ImageIcon, Sparkles,
+  Upload, X, ImageIcon, Sparkles, Trophy,
+  Gamepad2, MapPinned, ShieldCheck, Users,
+  Clock, Banknote, RadioTower, ListChecks,
+  Eye, EyeOff, Zap,
 } from 'lucide-react';
 import { useEventsToken } from '@/hooks/useEventsToken';
 import { createEvent, uploadEventBanner, deleteEventBanner, EventStatus, TournamentFormat, VetoMode } from '@/lib/event-api';
@@ -236,6 +239,73 @@ const DATE_LABEL: Record<DateTarget, string> = {
   deadline: 'Reg. Deadline',
 };
 
+type TournamentPreset = {
+  id: string;
+  label: string;
+  description: string;
+  patch: Partial<FormState>;
+};
+
+const TOURNAMENT_PRESETS: TournamentPreset[] = [
+  {
+    id: 'valorant_5v5',
+    label: 'Valorant 5v5 Cup',
+    description: 'Best fit for cafe LAN nights and tactical FPS events.',
+    patch: {
+      game: 'valorant',
+      format: 'single_elimination',
+      team_size: 5,
+      min_team_size: 5,
+      max_team_size: 5,
+      capacity_team: '16',
+      capacity_player: '80',
+      region: 'India',
+      server: 'Mumbai',
+      map_pool: 'Bind, Haven, Split, Ascent, Icebox, Lotus, Sunset',
+      veto_mode: 'bo1_ban_until_decider',
+      match_rules: 'Custom lobby. Captains confirm lobby before start. Winner must upload scoreboard screenshot. Result mismatch creates an admin dispute.',
+    },
+  },
+  {
+    id: 'solo_showdown',
+    label: 'Solo Showdown',
+    description: 'Quick individual tournament for walk-ins and daily cafe traffic.',
+    patch: {
+      game: 'custom',
+      format: 'single_elimination',
+      team_size: 1,
+      min_team_size: 1,
+      max_team_size: 1,
+      capacity_team: '32',
+      capacity_player: '32',
+      allow_solo: true,
+      allow_individual: true,
+      veto_mode: 'none',
+      match_rules: 'Single player entry. Admin verifies results manually. No-show after 10 minutes may be forfeited.',
+    },
+  },
+  {
+    id: 'weekend_cafe_cup',
+    label: 'Weekend Cafe Cup',
+    description: 'Prize-backed local event with controlled team capacity.',
+    patch: {
+      game: 'valorant',
+      format: 'single_elimination',
+      team_size: 5,
+      min_team_size: 5,
+      max_team_size: 5,
+      capacity_team: '8',
+      capacity_player: '40',
+      registration_fee: '500',
+      prize_pool: '5000',
+      region: 'India',
+      server: 'Mumbai',
+      veto_mode: 'bo1_ban_until_decider',
+      match_rules: 'Teams must check in at cafe desk. Admin assigns systems. Captains submit result screenshot after every match.',
+    },
+  },
+];
+
 export default function CreateTournamentPage() {
   const router = useRouter();
    const [vendorId, setVendorId] = useState<number | null>(null)
@@ -294,7 +364,36 @@ export default function CreateTournamentPage() {
 
   const set = <K extends keyof FormState>(k: K, v: FormState[K]) =>
     setForm((f) => ({ ...f, [k]: v }));
-  const sectionPanelClass = "gaming-panel rounded-xl border border-cyan-400/20 bg-slate-950/40 p-4 sm:p-5";
+  const applyPreset = (preset: TournamentPreset) => {
+    setForm((current) => ({ ...current, ...preset.patch }));
+  };
+  const applyQuickDate = (daysFromToday: number) => {
+    const start = new Date();
+    start.setDate(start.getDate() + daysFromToday);
+    start.setHours(18, 0, 0, 0);
+    const end = new Date(start);
+    end.setHours(23, 0, 0, 0);
+    const regDeadline = new Date(start);
+    regDeadline.setHours(12, 0, 0, 0);
+    setStartDate(start);
+    setEndDate(end);
+    setDeadline(regDeadline);
+    setActivePicker('start');
+  };
+  const mapPoolCount = form.map_pool.split(',').map((m) => m.trim()).filter(Boolean).length;
+  const maxTeams = parseInt(form.capacity_team) || 0;
+  const maxPlayers = parseInt(form.capacity_player) || (maxTeams && form.team_size ? maxTeams * form.team_size : 0);
+  const fee = parseFloat(form.registration_fee) || 0;
+  const prize = parseFloat(form.prize_pool) || 0;
+  const readyChecks = [
+    { label: 'Name', ready: Boolean(form.title.trim()) },
+    { label: 'Dates', ready: Boolean(startDate && endDate) },
+    { label: 'Game', ready: Boolean(form.game && form.format) },
+    { label: 'Capacity', ready: Boolean(maxTeams || maxPlayers) },
+    { label: 'Rules', ready: Boolean(form.match_rules.trim()) },
+  ];
+  const completionCount = readyChecks.filter((item) => item.ready).length;
+  const sectionPanelClass = "gaming-panel rounded-xl border border-cyan-400/20 bg-slate-950/45 p-4 sm:p-5";
   const labelClass = "mb-1.5 block text-[11px] font-bold uppercase tracking-wider text-cyan-100/80 sm:text-xs";
   const inputClass = "h-10 w-full rounded-lg border border-cyan-400/25 bg-slate-900/70 px-3 text-sm text-slate-100 placeholder:text-slate-400 focus:outline-none focus:ring-2 focus:ring-cyan-400/60";
   const textareaClass = "w-full rounded-lg border border-cyan-400/25 bg-slate-900/70 px-3 py-2 text-sm text-slate-100 placeholder:text-slate-400 focus:outline-none focus:ring-2 focus:ring-cyan-400/60";
@@ -407,33 +506,84 @@ export default function CreateTournamentPage() {
 
   return (
     <DashboardLayout>
-    <div className="flex-1 space-y-3 overflow-y-auto sm:space-y-4">
+    <div className="flex-1 space-y-4 overflow-y-auto sm:space-y-5">
       <div className="gaming-panel rounded-xl p-4 sm:p-5">
-        <h1 className="premium-heading flex items-center gap-2">
-          Create New Tournament
-          <Sparkles className="h-4 w-4 text-emerald-400 sm:h-5 sm:w-5" />
-        </h1>
-        <p className="premium-subtle mt-1">
-          Fill in the details below to set up your new eSports event.
-        </p>
+        <div className="flex flex-wrap items-start justify-between gap-4">
+          <div className="max-w-3xl">
+            <div className="mb-2 inline-flex items-center gap-2 rounded-full border border-emerald-400/25 bg-emerald-500/10 px-3 py-1 text-xs font-semibold uppercase tracking-wider text-emerald-200">
+              <Zap className="h-3.5 w-3.5" />
+              Organizer setup
+            </div>
+            <h1 className="premium-heading flex items-center gap-2">
+              Create Tournament
+              <Sparkles className="h-4 w-4 text-emerald-400 sm:h-5 sm:w-5" />
+            </h1>
+            <p className="premium-subtle mt-1 max-w-2xl">
+              Set the public listing, cafe logistics, match engine, and payout details from one control page.
+            </p>
+          </div>
+
+          <div className="grid min-w-[220px] grid-cols-2 gap-2 rounded-xl border border-cyan-400/20 bg-slate-950/50 p-3">
+            <div>
+              <p className="text-[10px] font-bold uppercase tracking-wider text-cyan-100/60">Readiness</p>
+              <p className="mt-1 text-2xl font-bold text-cyan-100">{completionCount}/5</p>
+            </div>
+            <div>
+              <p className="text-[10px] font-bold uppercase tracking-wider text-cyan-100/60">Status</p>
+              <p className="mt-1 text-sm font-semibold text-slate-100">{form.status === 'published' ? 'Publishing' : 'Draft'}</p>
+            </div>
+            <div className="col-span-2 grid grid-cols-5 gap-1">
+              {readyChecks.map((item) => (
+                <div
+                  key={item.label}
+                  className={`h-1.5 rounded-full ${item.ready ? 'bg-emerald-400' : 'bg-slate-700'}`}
+                  title={item.label}
+                />
+              ))}
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <div className="gaming-panel rounded-xl border border-cyan-400/20 bg-slate-950/45 p-3 sm:p-4">
+        <div className="mb-3 flex items-center justify-between gap-3">
+          <div>
+            <h2 className="section-title flex items-center gap-2">
+              <Trophy className="h-4 w-4 text-cyan-300" />
+              Fast Setup Presets
+            </h2>
+            <p className="premium-subtle text-sm">Start from a cafe-ready template, then tune the details.</p>
+          </div>
+        </div>
+        <div className="grid grid-cols-1 gap-3 lg:grid-cols-3">
+          {TOURNAMENT_PRESETS.map((preset) => (
+            <button
+              key={preset.id}
+              type="button"
+              onClick={() => applyPreset(preset)}
+              className="group rounded-lg border border-cyan-400/15 bg-slate-900/60 p-3 text-left transition-all hover:border-cyan-300/45 hover:bg-slate-800/70"
+            >
+              <div className="flex items-center justify-between gap-3">
+                <span className="text-sm font-semibold text-cyan-100">{preset.label}</span>
+                <span className="rounded-md border border-cyan-300/20 px-2 py-1 text-[10px] font-bold uppercase tracking-wider text-cyan-200 group-hover:bg-cyan-500/10">
+                  Apply
+                </span>
+              </div>
+              <p className="mt-2 text-xs leading-5 text-slate-400">{preset.description}</p>
+            </button>
+          ))}
+        </div>
       </div>
 
       <div className="w-full pb-6">
         <div className="grid grid-cols-1 gap-4 xl:grid-cols-12">
 
-          <section className={`${sectionPanelClass} xl:col-span-6`}>
-            <h2 className="section-title mb-1">Event Banner</h2>
-            <div className="h-px bg-cyan-500/20 mb-5" />
-            <BannerUploader
-              preview={bannerPreview}
-              uploading={bannerUploading}
-              onFileSelect={handleBannerSelect}
-              onRemove={handleBannerRemove}
-            />
-          </section>
-
-          <section className={`${sectionPanelClass} xl:col-span-6`}>
-            <h2 className="section-title mb-1">Basic Information</h2>
+          <section className={`${sectionPanelClass} xl:col-span-7`}>
+            <h2 className="section-title mb-1 flex items-center gap-2">
+              <ListChecks className="h-4 w-4 text-cyan-300" />
+              Public Listing
+            </h2>
+            <p className="premium-subtle mb-4 text-sm">What players see before they register.</p>
             <div className="h-px bg-cyan-500/20 mb-5" />
             <div className="space-y-4">
               <div>
@@ -449,15 +599,30 @@ export default function CreateTournamentPage() {
                 <label className={labelClass}>Description</label>
                 <textarea
                   className={textareaClass}
-                  rows={3}
-                  placeholder="e.g., 5v5 GTA single-elim tournament"
+                  rows={4}
+                  placeholder="Mention game mode, cafe check-in, prize highlights, and who can join."
                   value={form.description}
                   onChange={(e) => set('description', e.target.value)}
                 />
               </div>
-              <div className="two-col-grid">
+              <div className="grid grid-cols-1 gap-3 md:grid-cols-3">
                 <div>
-                  <label className={labelClass}>Publish Status</label>
+                  <label className={labelClass}>Visibility</label>
+                  <button
+                    type="button"
+                    onClick={() => set('visibility', !form.visibility)}
+                    className={`flex h-10 w-full items-center justify-center gap-2 rounded-lg border px-3 text-sm font-semibold transition-all ${
+                      form.visibility
+                        ? 'border-emerald-400/35 bg-emerald-500/10 text-emerald-100'
+                        : 'border-slate-600 bg-slate-900/70 text-slate-300'
+                    }`}
+                  >
+                    {form.visibility ? <Eye className="h-4 w-4" /> : <EyeOff className="h-4 w-4" />}
+                    {form.visibility ? 'Public' : 'Hidden'}
+                  </button>
+                </div>
+                <div>
+                  <label className={labelClass}>Publishing</label>
                   <select
                     className={selectClass}
                     value={form.status}
@@ -483,11 +648,46 @@ export default function CreateTournamentPage() {
             </div>
           </section>
 
-          <section className={`${sectionPanelClass} xl:col-span-8`}>
-            <h2 className="section-title mb-1">Schedule & Logistics</h2>
+          <section className={`${sectionPanelClass} xl:col-span-5`}>
+            <h2 className="section-title mb-1 flex items-center gap-2">
+              <ImageIcon className="h-4 w-4 text-cyan-300" />
+              Banner
+            </h2>
+            <p className="premium-subtle mb-4 text-sm">A strong banner makes the public tournament card easier to trust.</p>
+            <div className="h-px bg-cyan-500/20 mb-5" />
+            <BannerUploader
+              preview={bannerPreview}
+              uploading={bannerUploading}
+              onFileSelect={handleBannerSelect}
+              onRemove={handleBannerRemove}
+            />
+          </section>
+
+          <section className={`${sectionPanelClass} xl:col-span-7`}>
+            <h2 className="section-title mb-1 flex items-center gap-2">
+              <Clock className="h-4 w-4 text-cyan-300" />
+              Schedule & Check-in
+            </h2>
+            <p className="premium-subtle mb-4 text-sm">Pick match day first, then set the registration cutoff.</p>
             <div className="h-px bg-cyan-500/20 mb-5" />
 
             <label className={`${labelClass} mb-3`}>Tournament Dates *</label>
+            <div className="mb-3 flex flex-wrap gap-2">
+              {[
+                { label: 'Tonight', days: 0 },
+                { label: 'Tomorrow', days: 1 },
+                { label: 'This Weekend', days: 3 },
+              ].map((item) => (
+                <button
+                  key={item.label}
+                  type="button"
+                  onClick={() => applyQuickDate(item.days)}
+                  className="rounded-lg border border-cyan-300/20 bg-slate-900/70 px-3 py-2 text-xs font-semibold text-slate-200 transition-all hover:border-cyan-300/45 hover:bg-slate-800"
+                >
+                  {item.label}
+                </button>
+              ))}
+            </div>
             <div className="flex gap-2 mb-4 flex-wrap">
               {(['start', 'end', 'deadline'] as DateTarget[]).map((t) => (
                 <button
@@ -517,79 +717,36 @@ export default function CreateTournamentPage() {
               />
 
               <div className="space-y-4">
-                <div>
-                  <label className={labelClass}>Max Teams</label>
-                  <input
-                    className={inputClass}
-                    type="number"
-                    min={1}
-                    placeholder="e.g., 32"
-                    value={form.capacity_team}
-                    onChange={(e) => set('capacity_team', e.target.value)}
-                  />
-                </div>
-                <div>
-                  <label className={labelClass}>Max Players</label>
-                  <input
-                    className={inputClass}
-                    type="number"
-                    min={1}
-                    placeholder="e.g., 160"
-                    value={form.capacity_player}
-                    onChange={(e) => set('capacity_player', e.target.value)}
-                  />
-                </div>
-                <div>
-                  <label className={labelClass}>Team Size Range</label>
-                  <div className="flex items-center gap-2">
-                    <input
-                      className={inputClass}
-                      type="number"
-                      min={1}
-                      placeholder="Min"
-                      value={form.min_team_size}
-                      onChange={(e) =>
-                        set('min_team_size', parseInt(e.target.value) || 1)
-                      }
-                    />
-                    <span className="text-muted-foreground font-medium">–</span>
-                    <input
-                      className={inputClass}
-                      type="number"
-                      min={1}
-                      placeholder="Max"
-                      value={form.max_team_size}
-                      onChange={(e) =>
-                        set('max_team_size', parseInt(e.target.value) || 1)
-                      }
-                    />
+                <div className="rounded-lg border border-cyan-400/15 bg-slate-900/55 p-3">
+                  <p className="text-xs font-bold uppercase tracking-wider text-cyan-100/70">Suggested operations</p>
+                  <div className="mt-3 space-y-2 text-sm text-slate-300">
+                    <div className="flex items-start gap-2">
+                      <ShieldCheck className="mt-0.5 h-4 w-4 text-emerald-300" />
+                      <span>Open check-in from the tournament detail page after registration closes.</span>
+                    </div>
+                    <div className="flex items-start gap-2">
+                      <CalendarDays className="mt-0.5 h-4 w-4 text-cyan-300" />
+                      <span>Generate bracket only after confirmed teams are ready.</span>
+                    </div>
+                    <div className="flex items-start gap-2">
+                      <Users className="mt-0.5 h-4 w-4 text-blue-300" />
+                      <span>Use capacity to match available PCs/consoles and cafe seating.</span>
+                    </div>
                   </div>
-                </div>
-                <div className="space-y-2 pt-1">
-                  {([
-                    { key: 'allow_solo'       as const, label: 'Allow Solo Players'            },
-                    { key: 'allow_individual' as const, label: 'Allow Individual Registration' },
-                    { key: 'visibility'       as const, label: 'Visible to Public'             },
-                  ]).map(({ key, label }) => (
-                    <label key={key} className="flex items-center gap-3 cursor-pointer select-none">
-                      <input
-                        type="checkbox"
-                        checked={form[key] as boolean}
-                        onChange={(e) => set(key, e.target.checked)}
-                        className="h-4 w-4 rounded border-cyan-400/30 bg-slate-900/70 accent-cyan-400"
-                      />
-                      <span className="body-text">{label}</span>
-                    </label>
-                  ))}
                 </div>
               </div>
             </div>
           </section>
 
-          <section className={`${sectionPanelClass} xl:col-span-4`}>
-            <h2 className="section-title mb-1">Tournament Engine</h2>
+          <section className={`${sectionPanelClass} xl:col-span-5`}>
+            <h2 className="section-title mb-1 flex items-center gap-2">
+              <Gamepad2 className="h-4 w-4 text-cyan-300" />
+              Match Engine
+            </h2>
+            <p className="premium-subtle mb-4 text-sm">How Hash will seed, create matches, and guide captains.</p>
             <div className="h-px bg-cyan-500/20 mb-5" />
             <div className="space-y-4">
+              <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
               <div>
                 <label className={labelClass}>Game</label>
                 <select
@@ -619,6 +776,7 @@ export default function CreateTournamentPage() {
                   <option value="daily_cup" disabled>Daily Cup - Phase 2</option>
                 </select>
               </div>
+              </div>
               <div>
                 <label className={labelClass}>Region / Server</label>
                 <div className="grid grid-cols-1 gap-2 sm:grid-cols-2">
@@ -637,13 +795,14 @@ export default function CreateTournamentPage() {
                 </div>
               </div>
               <div>
-                <label className={labelClass}>Valorant Map Pool</label>
+                <label className={labelClass}>Map Pool</label>
                 <input
                   className={inputClass}
                   placeholder="Bind, Haven, Ascent"
                   value={form.map_pool}
                   onChange={(e) => set('map_pool', e.target.value)}
                 />
+                <p className="mt-1 text-xs text-slate-400">{mapPoolCount} maps configured for veto/admin selection.</p>
               </div>
               <div>
                 <label className={labelClass}>Map Veto</label>
@@ -670,35 +829,34 @@ export default function CreateTournamentPage() {
             </div>
           </section>
 
-          <section className={`${sectionPanelClass} xl:col-span-4`}>
-            <h2 className="section-title mb-1">Financials</h2>
+          <section className={`${sectionPanelClass} xl:col-span-7`}>
+            <h2 className="section-title mb-1 flex items-center gap-2">
+              <Users className="h-4 w-4 text-cyan-300" />
+              Capacity & Prize
+            </h2>
+            <p className="premium-subtle mb-4 text-sm">Keep this aligned with available PCs/consoles, seating, and staff bandwidth.</p>
             <div className="h-px bg-cyan-500/20 mb-5" />
-            <div className="space-y-4">
+            <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
               <div>
-                <label className={labelClass}>
-                  Entry / Registration Fee ({form.currency})
-                </label>
+                <label className={labelClass}>Max Teams</label>
                 <input
                   className={inputClass}
                   type="number"
-                  min={0}
-                  step="0.01"
-                  placeholder="e.g., 10"
-                  value={form.registration_fee}
-                  onChange={(e) => set('registration_fee', e.target.value)}
+                  min={1}
+                  placeholder="e.g., 16"
+                  value={form.capacity_team}
+                  onChange={(e) => set('capacity_team', e.target.value)}
                 />
               </div>
               <div>
-                <label className={labelClass}>
-                  Prize Pool ({form.currency})
-                </label>
+                <label className={labelClass}>Max Players</label>
                 <input
                   className={inputClass}
                   type="number"
-                  min={0}
-                  placeholder="e.g., 1000"
-                  value={form.prize_pool}
-                  onChange={(e) => set('prize_pool', e.target.value)}
+                  min={1}
+                  placeholder="e.g., 80"
+                  value={form.capacity_player}
+                  onChange={(e) => set('capacity_player', e.target.value)}
                 />
               </div>
               <div>
@@ -716,8 +874,111 @@ export default function CreateTournamentPage() {
                   }}
                 />
               </div>
+              <div>
+                <label className={labelClass}>Team Size Range</label>
+                <div className="flex items-center gap-2">
+                  <input
+                    className={inputClass}
+                    type="number"
+                    min={1}
+                    placeholder="Min"
+                    value={form.min_team_size}
+                    onChange={(e) =>
+                      set('min_team_size', parseInt(e.target.value) || 1)
+                    }
+                  />
+                  <span className="text-muted-foreground font-medium">–</span>
+                  <input
+                    className={inputClass}
+                    type="number"
+                    min={1}
+                    placeholder="Max"
+                    value={form.max_team_size}
+                    onChange={(e) =>
+                      set('max_team_size', parseInt(e.target.value) || 1)
+                    }
+                  />
+                </div>
+              </div>
+              <div>
+                <label className={labelClass}>
+                  Entry Fee ({form.currency})
+                </label>
+                <input
+                  className={inputClass}
+                  type="number"
+                  min={0}
+                  step="0.01"
+                  placeholder="e.g., 500"
+                  value={form.registration_fee}
+                  onChange={(e) => set('registration_fee', e.target.value)}
+                />
+              </div>
+              <div>
+                <label className={labelClass}>
+                  Prize Pool ({form.currency})
+                </label>
+                <input
+                  className={inputClass}
+                  type="number"
+                  min={0}
+                  placeholder="e.g., 5000"
+                  value={form.prize_pool}
+                  onChange={(e) => set('prize_pool', e.target.value)}
+                />
+              </div>
+              <div className="md:col-span-2">
+                <div className="grid grid-cols-1 gap-2 sm:grid-cols-2">
+                  {([
+                    { key: 'allow_solo'       as const, label: 'Allow solo players'            },
+                    { key: 'allow_individual' as const, label: 'Allow individual registration' },
+                  ]).map(({ key, label }) => (
+                    <button
+                      key={key}
+                      type="button"
+                      onClick={() => set(key, !(form[key] as boolean))}
+                      className={`flex items-center justify-between rounded-lg border px-3 py-2 text-left text-sm font-semibold transition-all ${
+                        form[key]
+                          ? 'border-emerald-400/35 bg-emerald-500/10 text-emerald-100'
+                          : 'border-cyan-400/15 bg-slate-900/60 text-slate-300'
+                      }`}
+                    >
+                      {label}
+                      <span className="text-xs">{form[key] ? 'On' : 'Off'}</span>
+                    </button>
+                  ))}
+                </div>
+              </div>
             </div>
           </section>
+
+          <aside className={`${sectionPanelClass} xl:col-span-12`}>
+            <div className="grid grid-cols-1 gap-3 lg:grid-cols-5">
+              {[
+                { label: 'Game', value: form.game || 'Not set', icon: <Gamepad2 className="h-4 w-4 text-cyan-300" /> },
+                { label: 'Teams', value: maxTeams ? `${maxTeams} max` : 'Unset', icon: <Users className="h-4 w-4 text-blue-300" /> },
+                { label: 'Server', value: form.server || form.region || 'Unset', icon: <RadioTower className="h-4 w-4 text-emerald-300" /> },
+                { label: 'Prize', value: `${form.currency} ${prize}`, icon: <Banknote className="h-4 w-4 text-yellow-300" /> },
+                { label: 'Fee', value: `${form.currency} ${fee}`, icon: <Trophy className="h-4 w-4 text-orange-300" /> },
+              ].map((item) => (
+                <div key={item.label} className="rounded-lg border border-cyan-400/15 bg-slate-900/60 p-3">
+                  <div className="flex items-center gap-2">
+                    {item.icon}
+                    <p className="text-[10px] font-bold uppercase tracking-wider text-cyan-100/60">{item.label}</p>
+                  </div>
+                  <p className="mt-2 truncate text-sm font-semibold text-slate-100">{item.value}</p>
+                </div>
+              ))}
+            </div>
+            <div className="mt-3 flex flex-wrap items-center gap-2 text-xs text-slate-400">
+              <MapPinned className="h-4 w-4 text-cyan-300" />
+              <span>{mapPoolCount ? `${mapPoolCount} maps ready` : 'No map pool configured'}</span>
+              <span className="text-slate-600">|</span>
+              <span>{maxPlayers ? `${maxPlayers} player capacity` : 'Player capacity can be auto-derived from teams and size'}</span>
+              <span className="text-slate-600">|</span>
+              <span>{form.format.replaceAll('_', ' ')}</span>
+            </div>
+          </aside>
 
           {error && (
             <div className="rounded-lg border border-red-500/30 bg-red-500/10 p-3 xl:col-span-12">


### PR DESCRIPTION
The create page at create/page.tsx is now reorganized for cafe organizers: Fast setup presets like Valorant 5v5, Solo Showdown, Weekend Cafe Cup Readiness checklist
Public listing section
Banner section
Schedule/check-in guidance
Match engine settings
Capacity and prize setup
Final launch summary
I also added missing tournament status management on the detail page at [id]/page.tsx: Draft
Published
Live
Completed
Canceled
It uses the existing updateEvent API, so organizers can now move a tournament from draft to published directly from the tournament management page. Verification:
Targeted TypeScript check shows no errors from the touched tournament files. Full dashboard typecheck still has unrelated existing errors in games/page.tsx and rapid-bookings.tsx.