### PR TITLE
Fixed the “All Statuses shows nothing” issue path in hash-dashboard.

### DIFF
--- a/app/(features)/tournaments/create/page.tsx
+++ b/app/(features)/tournaments/create/page.tsx
@@ -13,6 +13,7 @@ import { useEventsToken } from '@/hooks/useEventsToken';
 import { createEvent, uploadEventBanner, deleteEventBanner, EventStatus, TournamentFormat, VetoMode } from '@/lib/event-api';
 import { jwtDecode } from 'jwt-decode';
 import { DashboardLayout } from '@/app/(layout)/dashboard-layout';
+import { useDashboardData } from '@/app/context/DashboardDataContext';
 
  // TODO: replace with auth context
 
@@ -310,6 +311,7 @@ export default function CreateTournamentPage() {
   const router = useRouter();
    const [vendorId, setVendorId] = useState<number | null>(null)
   const { token, loading: tokenLoading } = useEventsToken(vendorId);
+  const { bumpModuleVersion } = useDashboardData();
 
   const [form, setForm] = useState<FormState>({
     title:            '',
@@ -493,6 +495,9 @@ export default function CreateTournamentPage() {
         banner_public_id,
       });
 
+      if (vendorId) {
+        bumpModuleVersion(`tournaments:${vendorId}`);
+      }
       router.push(`/tournaments/${ev.id}`);
     } catch (e) {
       setBannerUploading(false);

--- a/app/(features)/tournaments/page.tsx
+++ b/app/(features)/tournaments/page.tsx
@@ -4,7 +4,7 @@ import { useState, useEffect } from 'react';
 import { useRouter } from 'next/navigation';
 import {
   Plus, Search, MoreHorizontal, Trophy,
-  ChevronLeft, ChevronRight, Sparkles,
+  ChevronLeft, ChevronRight, Sparkles, RefreshCw,
 } from 'lucide-react';
 import { useEventsToken } from '@/hooks/useEventsToken';
 import { jwtDecode } from "jwt-decode"
@@ -46,6 +46,7 @@ export default function TournamentsPage() {
 
   const [events,       setEvents]       = useState<EventItem[]>([]);
   const [loadingData,  setLoadingData]  = useState(false);
+  const [dataError,    setDataError]    = useState<string | null>(null);
   const [search,       setSearch]       = useState('');
   const [statusFilter, setStatusFilter] = useState('');
   const [page,         setPage]         = useState(1);
@@ -84,14 +85,31 @@ export default function TournamentsPage() {
     if (!token) return;
     if (cachedEvents) {
       setEvents(cachedEvents);
-      return;
     }
     setLoadingData(true);
+    setDataError(null);
     refreshEventsCache(true)
       .then((data) => setEvents(data || []))
-      .catch(console.error)
+      .catch((error) => {
+        console.error(error);
+        setDataError(error instanceof Error ? error.message : 'Failed to load tournaments.');
+      })
       .finally(() => setLoadingData(false));
   }, [token, statusFilter, cachedEvents, refreshEventsCache]);
+
+  const handleRefreshEvents = async () => {
+    setLoadingData(true);
+    setDataError(null);
+    try {
+      const data = await refreshEventsCache(true);
+      setEvents(data || []);
+    } catch (error) {
+      console.error(error);
+      setDataError(error instanceof Error ? error.message : 'Failed to load tournaments.');
+    } finally {
+      setLoadingData(false);
+    }
+  };
 
   const filtered   = events.filter((e) =>
     e.title.toLowerCase().includes(search.toLowerCase())
@@ -166,7 +184,21 @@ export default function TournamentsPage() {
               <option key={s} value={s}>{STATUS_LABEL[s]}</option>
             ))}
           </select>
+          <button
+            className="inline-flex h-10 items-center justify-center gap-2 rounded-lg border border-cyan-300/25 bg-slate-900/70 px-3 text-xs font-semibold text-slate-200 transition-all hover:border-cyan-300/45 hover:bg-slate-800/80 hover:text-cyan-100 disabled:opacity-50"
+            onClick={handleRefreshEvents}
+            disabled={loadingData}
+          >
+            <RefreshCw className={`icon-sm ${loadingData ? 'animate-spin' : ''}`} />
+            Refresh
+          </button>
         </div>
+
+        {dataError && (
+          <div className="rounded-lg border border-rose-400/30 bg-rose-500/10 px-3 py-2 text-sm text-rose-200">
+            {dataError}
+          </div>
+        )}
 
         {/* ── Table ────────────────────────────────────── */}
         <div className="dashboard-table-shell">
@@ -200,9 +232,16 @@ export default function TournamentsPage() {
                       <p className="body-text-muted">
                         {search || statusFilter
                           ? 'No tournaments match your filters.'
-                          : 'No tournaments yet.'}
+                          : loadingData
+                            ? 'Checking latest tournaments...'
+                            : 'No tournaments returned for this cafe.'}
                       </p>
-                      {!search && !statusFilter && (
+                      {!search && !statusFilter && !loadingData && (
+                        <p className="max-w-md text-xs text-slate-400">
+                          If you just created one, use Refresh. If it still does not appear, the tournament may belong to another selected cafe/vendor.
+                        </p>
+                      )}
+                      {!search && !statusFilter && !loadingData && (
                         <button
                           className="btn-primary"
                           onClick={() => router.push('/tournaments/create')}

--- a/hooks/useEventsToken.ts
+++ b/hooks/useEventsToken.ts
@@ -6,6 +6,9 @@ import { getVendorJwt } from '@/lib/event-api';
 const LS_TOKEN = 'ev_jwt';
 const LS_EXP   = 'ev_jwt_exp';
 
+const tokenKey = (vendorId: number) => `${LS_TOKEN}:${vendorId}`;
+const expKey = (vendorId: number) => `${LS_EXP}:${vendorId}`;
+
 export function useEventsToken(vendorId: number | null) {
   const [token,   setToken]   = useState<string | null>(null);
   const [loading, setLoading] = useState(true);
@@ -17,6 +20,8 @@ export function useEventsToken(vendorId: number | null) {
     setError(null);
     try {
       const t = await getVendorJwt(vendorId, 480);
+      localStorage.setItem(tokenKey(vendorId), t);
+      localStorage.setItem(expKey(vendorId), String(Date.now() + 480 * 60 * 1000));
       localStorage.setItem(LS_TOKEN, t);
       localStorage.setItem(LS_EXP, String(Date.now() + 480 * 60 * 1000));
       setToken(t);
@@ -29,8 +34,8 @@ export function useEventsToken(vendorId: number | null) {
 
   useEffect(() => {
     if (!vendorId) return;
-    const stored = localStorage.getItem(LS_TOKEN);
-    const exp    = localStorage.getItem(LS_EXP);
+    const stored = localStorage.getItem(tokenKey(vendorId));
+    const exp    = localStorage.getItem(expKey(vendorId));
     if (stored && exp && Date.now() < Number(exp)) {
       setToken(stored);
       setLoading(false);


### PR DESCRIPTION
What I changed:
Tournament list now force-refreshes from backend instead of trusting a cached empty list. Added a visible Refresh button on the tournaments page. Added an error panel if the tournament API fails instead of silently showing “No tournaments.” Event JWT is now cached per vendor/cafe, so switching cafes will not reuse the wrong tournament token. Creating a tournament now bumps the tournaments cache version so the list refreshes after creation. Files changed:
tournaments/page.tsx
create/page.tsx
useEventsToken.ts
After deploy/reload, click Refresh once on /tournaments. If it still shows empty, the new message will help confirm whether the tournament belongs to another selected cafe/vendor or the backend request is failing. Verification: touched tournament files have no TypeScript errors. The remaining TypeScript errors are existing unrelated ones in games/page.tsx and rapid-bookings.tsx.