### PR TITLE
Frontend hash-dashboard now normalizes displayed tournament status fr…

### DIFF
--- a/app/(features)/tournaments/[id]/page.tsx
+++ b/app/(features)/tournaments/[id]/page.tsx
@@ -14,7 +14,7 @@ import {
   TeamItem, publishResults, WinnerInput,
   getTournamentDetail, openCheckIn, closeCheckIn, generateBracket,
   startMatch, submitAdminMatchResult, resolveMatchDispute, TournamentMatch,
-  TournamentDetail, updateEvent,
+  TournamentDetail, updateEvent, withEffectiveEventStatus,
 } from '@/lib/event-api';
 import { jwtDecode } from 'jwt-decode';
 import { DashboardLayout } from '@/app/(layout)/dashboard-layout';
@@ -137,7 +137,7 @@ export default function TournamentDetailPage() {
 
   const hydrateDetail = useCallback((detail: TournamentDetail | null | undefined) => {
     if (!detail) return;
-    setEvent(detail.event ?? null);
+    setEvent(detail.event ? withEffectiveEventStatus(detail.event) : null);
     setRegistrations(detail.registrations || []);
     setTeams(detail.teams || []);
     setMatches(detail.matches || []);
@@ -216,7 +216,7 @@ export default function TournamentDetailPage() {
     setStatusBusy(nextStatus);
     try {
       await updateEvent(token, eventId, { status: nextStatus });
-      setEvent((prev) => prev ? { ...prev, status: nextStatus } : prev);
+      setEvent((prev) => prev ? withEffectiveEventStatus({ ...prev, status: nextStatus }) : prev);
       await refreshDetailCache(true).then(hydrateDetail).catch(() => null);
     } catch (error: any) {
       setStatusError(error?.message || 'Failed to update tournament status.');

--- a/app/(features)/tournaments/create/page.tsx
+++ b/app/(features)/tournaments/create/page.tsx
@@ -10,7 +10,7 @@ import {
   Eye, EyeOff, Zap,
 } from 'lucide-react';
 import { useEventsToken } from '@/hooks/useEventsToken';
-import { createEvent, uploadEventBanner, deleteEventBanner, EventStatus, TournamentFormat, VetoMode } from '@/lib/event-api';
+import { createEvent, uploadEventBanner, deleteEventBanner, EventStatus, TournamentFormat, VetoMode, getEffectiveEventStatus } from '@/lib/event-api';
 import { jwtDecode } from 'jwt-decode';
 import { DashboardLayout } from '@/app/(layout)/dashboard-layout';
 import { useDashboardData } from '@/app/context/DashboardDataContext';
@@ -438,6 +438,22 @@ export default function CreateTournamentPage() {
     deadline: deadline,
   };
 
+  const expectedStatus = startDate && endDate
+    ? getEffectiveEventStatus({
+        status: form.status,
+        start_at: startDate.toISOString(),
+        end_at: endDate.toISOString(),
+      })
+    : form.status;
+
+  const expectedStatusLabel: Record<EventStatus, string> = {
+    draft: 'Draft',
+    published: 'Published',
+    ongoing: 'Live',
+    completed: 'Completed',
+    canceled: 'Canceled',
+  };
+
   // ── Validation + Submit ───────────────────────────
   const handleSubmit = async () => {
     if (!token)                          return setError('Session not ready. Please wait a moment.');
@@ -535,7 +551,7 @@ export default function CreateTournamentPage() {
             </div>
             <div>
               <p className="text-[10px] font-bold uppercase tracking-wider text-cyan-100/60">Status</p>
-              <p className="mt-1 text-sm font-semibold text-slate-100">{form.status === 'published' ? 'Publishing' : 'Draft'}</p>
+              <p className="mt-1 text-sm font-semibold text-slate-100">{expectedStatusLabel[expectedStatus]}</p>
             </div>
             <div className="col-span-2 grid grid-cols-5 gap-1">
               {readyChecks.map((item) => (

--- a/app/(features)/tournaments/page.tsx
+++ b/app/(features)/tournaments/page.tsx
@@ -8,7 +8,7 @@ import {
 } from 'lucide-react';
 import { useEventsToken } from '@/hooks/useEventsToken';
 import { jwtDecode } from "jwt-decode"
-import { listEvents, EventItem, EventStatus } from '@/lib/event-api';
+import { listEvents, EventItem, EventStatus, withEffectiveEventStatus } from '@/lib/event-api';
 import { DashboardLayout } from '@/app/(layout)/dashboard-layout';
 import { useModuleCache } from '@/app/hooks/useModuleCache';
 import { useDashboardData } from '@/app/context/DashboardDataContext';
@@ -75,7 +75,8 @@ export default function TournamentsPage() {
     cacheKey,
     async () => {
       if (!token) return [];
-      return listEvents(token, statusFilter || undefined);
+      const data = await listEvents(token, statusFilter || undefined);
+      return data.map(withEffectiveEventStatus);
     },
     120000,
     versionKey
@@ -84,12 +85,12 @@ export default function TournamentsPage() {
   useEffect(() => {
     if (!token) return;
     if (cachedEvents) {
-      setEvents(cachedEvents);
+      setEvents(cachedEvents.map(withEffectiveEventStatus));
     }
     setLoadingData(true);
     setDataError(null);
     refreshEventsCache(true)
-      .then((data) => setEvents(data || []))
+      .then((data) => setEvents((data || []).map(withEffectiveEventStatus)))
       .catch((error) => {
         console.error(error);
         setDataError(error instanceof Error ? error.message : 'Failed to load tournaments.');
@@ -102,7 +103,7 @@ export default function TournamentsPage() {
     setDataError(null);
     try {
       const data = await refreshEventsCache(true);
-      setEvents(data || []);
+      setEvents((data || []).map(withEffectiveEventStatus));
     } catch (error) {
       console.error(error);
       setDataError(error instanceof Error ? error.message : 'Failed to load tournaments.');

--- a/lib/event-api.ts
+++ b/lib/event-api.ts
@@ -168,6 +168,29 @@ export interface TournamentDetail {
   matches: TournamentMatch[];
 }
 
+const DATE_MANAGED_EVENT_STATUSES: EventStatus[] = ['published', 'ongoing'];
+
+export function getEffectiveEventStatus(event: Pick<EventItem, 'status' | 'start_at' | 'end_at'>): EventStatus {
+  if (!DATE_MANAGED_EVENT_STATUSES.includes(event.status)) {
+    return event.status;
+  }
+
+  const startAt = new Date(event.start_at).getTime();
+  const endAt = new Date(event.end_at).getTime();
+  const now = Date.now();
+
+  if (!Number.isFinite(startAt) || !Number.isFinite(endAt)) {
+    return event.status;
+  }
+  if (now > endAt) return 'completed';
+  if (now >= startAt) return 'ongoing';
+  return 'published';
+}
+
+export function withEffectiveEventStatus<T extends Pick<EventItem, 'status' | 'start_at' | 'end_at'>>(event: T): T {
+  return { ...event, status: getEffectiveEventStatus(event) };
+}
+
 // ─── JWT ─────────────────────────────────────────────────────────────────────
 
 export async function getVendorJwt(


### PR DESCRIPTION
…om dates too, so cached rows and optimistic updates don’t show stale status.

Shared helper in [event-api.ts (line 173)](/Users/bhanujoshi/Documents/Hash/hash-dashboard/lib/event-api.ts:173) Applied in list/detail/create pages:[tournaments/page.tsx (line 74)](/Users/bhanujoshi/Documents/Hash/hash-dashboard/app/(features\)/tournaments/page.tsx:74) [tournaments/[id\]/page.tsx (line 138)](/Users/bhanujoshi/Documents/Hash/hash-dashboard/app/(features\)/tournaments/[id]/page.tsx:138) [tournaments/create/page.tsx (line 441)](/Users/bhanujoshi/Documents/Hash/hash-dashboard/app/(features\)/tournaments/create/page.tsx:441)